### PR TITLE
Add getting-started guidance for new ETL contributors

### DIFF
--- a/docs/getting-started/getting-started.qmd
+++ b/docs/getting-started/getting-started.qmd
@@ -4,7 +4,7 @@ format: html
 engine: knitr
 ---
 
-##Getting Started
+## Getting Started
 
 Please join us on the Getting Started meeting every other Monday at 10am ET
 
@@ -14,3 +14,40 @@ Next meeting: October 13, 2025 and every other Monday thereafter
 
 •	[Getting Started meeting link](https://teams.microsoft.com/l/meetup-join/19%3ameeting_YjVkMjBmZTgtZjM0MS00N2QwLWIzODctZTNlMjA1MmUxYzA5%40thread.v2/0?context=%7b%22Tid%22%3a%2214b77578-9773-42d5-8507-251ca2dc2b06%22%2c%22Oid%22%3a%2289bf3edf-e8d2-4417-9263-838fe9354d6b%22%7d)
 
+## Core OHDSI Resources
+
+New to ETLing your source data to the OMOP Common Data Model? Start here:
+
+•	[Book of OHDSI](https://ohdsi.github.io/TheBookOfOhdsi/) — the primary reference text for the OHDSI community and the OMOP CDM.
+
+•	[Athena](http://Athena.ohdsi.org) — the OHDSI vocabulary repository, used to browse and download standardized vocabularies for mapping source codes to OMOP concepts.
+
+•	[OMOP CDM home page](https://ohdsi.github.io/CommonDataModel/) — the Common Data Model specification.
+
+•	[CDM GitHub](https://github.com/OHDSI/CommonDataModel) — source repository for the CDM specification and DDL scripts.
+
+## EHR & Source Data Guidance
+
+•	[OMOP code on Epic user web](https://userweb.epic.com/Thread/99407/OMOP-All-of-Us-Master-OMOP-Thread/) — community thread on Epic User Web discussing OMOP mapping approaches for Epic source data. Requires an Epic User Web account.
+
+<!-- TODO: add guidance/links for other EHR source systems (e.g., Cerner/Oracle Health, athenahealth, other proprietary or open-source EHRs) as they become available. -->
+
+Before extracting and sharing data, review the [Proprietary and PHI considerations](../resources/proprietary.qmd) page for guidance on data governance responsibilities.
+
+## Tutorials
+
+•	[OHDSI ETL Tutorial](https://github.com/OHDSI/Tutorial-ETL) — walkthrough materials for building an ETL pipeline to the OMOP CDM.
+
+•	[EHDEN Academy](https://academy.ehden.eu) — free online courses covering OMOP CDM, vocabulary mapping, and OHDSI tools.
+
+## Interface Terminologies & Their Use in ETL/Mapping
+
+Interface terminologies (e.g., the clinical vocabularies used natively within an EHR, such as SNOMED CT, LOINC, or RxNorm) often differ from the standard vocabularies used in the OMOP CDM. Understanding how your source system's interface terminology relates to OMOP standard concepts is a key step in ETL design.
+
+•	[USAGI](https://github.com/OHDSI/Usagi) — a tool to support the manual mapping of source codes to standard OMOP concepts.
+
+•	[Themis convention library](https://ohdsi.github.io/Themis/) — community conventions for consistent ETL/mapping decisions across the OHDSI network.
+
+<!-- TODO: add specific guidance on mapping common interface terminologies (SNOMED CT, LOINC, RxNorm, ICD, etc.) to OMOP standard vocabularies. -->
+
+See the [Resources Overview](../resources/Overview.qmd) page for the full list of OHDSI tools and working group links.


### PR DESCRIPTION
## Summary
- Expands the Getting Started page (`docs/getting-started/getting-started.qmd`) with guidance for those new to ETLing source data, per #6
- Adds sections: Core OHDSI Resources (Book of OHDSI, Athena, CDM specs), EHR & Source Data Guidance, Tutorials, and Interface Terminologies in ETL/Mapping
- Reuses existing verified links from `docs/resources/Overview.qmd` where available, and cross-links to `docs/resources/proprietary.qmd`
- Two `<!-- TODO -->` markers remain for content not yet available (additional EHR source system guidance, and specific interface-terminology-to-OMOP mapping guidance) — flagged for follow-up rather than guessed

## Verification
- Rendered locally with Quarto CLI (`quarto render docs/getting-started/getting-started.qmd`) — builds with no errors
- Confirmed new sections and TODO markers appear correctly in the rendered HTML output

Closes #6